### PR TITLE
Exclude package-lock.json in .gitignore, previously just unstaged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 /node_modules
 /yarn-error.log
+/package-lock.json
 
 # Tern
 


### PR DESCRIPTION
This should make development a bit easier (`git add .`, instead of adding everything except for `package-lock.json`)