### PR TITLE
Add support for plaintext files

### DIFF
--- a/bin/uniread.js
+++ b/bin/uniread.js
@@ -21,7 +21,7 @@ const run = () => {
 	spritz.getBook(file).then((book) => {
 		cli(book);
 	}).catch(() => {
-		console.log("Book format not supported. ");
+		console.log("Book format not supported");
 		process.exit(1);
 	});
 };

--- a/src/sources/index.js
+++ b/src/sources/index.js
@@ -3,7 +3,8 @@ const fs = require("fs");
 
 const engines = {
 	epub: require("./epub"),
-	pdf: require("./pdf")
+	pdf: require("./pdf"),
+	text: require("./text")
 };
 	
 
@@ -14,12 +15,13 @@ module.exports = {
 
 		const type = fileType(data);
 
-		if(!type){
-			return false;
+		if(type !== null && engines[type.ext] !== undefined){
+			return engines[type.ext];
 		}
 
-		if(engines[type.ext] !== undefined){
-			return engines[type.ext];
+		// `file-type` does not detect plaintext files
+		if(filename.endsWith(".txt")) {
+			return engines.text;
 		}
 
 		return false;

--- a/src/sources/pdf/index.js
+++ b/src/sources/pdf/index.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 module.exports = (filename) => {
 	const book = {
 		_book: undefined,
+
 		_init: () => {
 			return new Promise((resolve) => {
 				fs.readFile(filename, function (err, data) {
@@ -20,22 +21,22 @@ module.exports = (filename) => {
 		},
 
 		getTitle: () => {
-			return "";
+			return filename;
 		},
 		getChapters: () => {
 			return new Promise((resolve) => {
 				book._readAllPages().then((content) => {
 					let chapters = [{
 						id: 1,
-						title: "Content not supported in pdf right now. ",
+						title: "Content not supported in pdf files yet.",
 						content: content.join(" ")
-					}];	
+					}];
 
 					resolve(chapters);
 				});
 			});
 		},
-		_readPage: function(id){
+		_readPage: (id) => {
 			var promise = new Promise(function(resolve){
 				book._book.getPage(id).then(function(page){
 					page.getTextContent().then(function(page){
@@ -54,10 +55,10 @@ module.exports = (filename) => {
 
 			return promise;
 		},
-		_readAllPages: function(){
+		_readAllPages: () => {
 			var promise = new Promise(function(resolve){
 				var pages = [];
-				
+
 				for(var i = 0; i < book._book.pdfInfo.numPages; i++){
 					pages.push(book._readPage(i + 1));
 				}

--- a/src/sources/text/index.js
+++ b/src/sources/text/index.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+
+module.exports = (filename) => {
+	const book = {
+		_book: undefined,
+		_init: () => {
+			return new Promise((resolve) => {
+				fs.readFile(filename, function (err, data) {
+					let text = data.toString();
+					book._book = text;
+					resolve(book);
+				});
+			});
+		},
+		getTitle: () => {
+			return filename;
+		},
+		getChapters: () => {
+			return new Promise((resolve) => {
+				let chapters = [{
+					id: 1,
+					title: "Content not supported in text files.",
+					content: book._book
+				}];
+
+				resolve(chapters);
+			});
+		}
+	};
+
+	return book._init(filename);
+};


### PR DESCRIPTION
TODO:

- add tests
- perhaps treat `.md`, `.markdown` and other text-based file formats as plaintext